### PR TITLE
add discernible text to header buttons

### DIFF
--- a/src/app/components/atoms/searchButton/SearchButton.tsx
+++ b/src/app/components/atoms/searchButton/SearchButton.tsx
@@ -15,13 +15,13 @@ const SearchButton = ({ onClick, keyword, setKeyword, searchOpen, toggleSearch }
   const { themeColor } = useContext(ThemeColorContext);
 
   const onChangeSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log('onChangeSearch', e.target.value)
+    console.log('onChangeSearch', e.target.value);
     setKeyword(e.target.value);
   };
 
   const clickEnterKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
     //IMEの変換中はEnterキーで動作しない
-    if (e.key === 'Enter'&& !e.nativeEvent.isComposing) {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       onClick();
     }
   };
@@ -71,7 +71,7 @@ const SearchButton = ({ onClick, keyword, setKeyword, searchOpen, toggleSearch }
           className="block md:hidden border rounded p-1"
         />
       )} */}
-      <button onClick={onClick} className="hidden md:block mx-2">
+      <button onClick={onClick} className="hidden md:block mx-2" aria-label="検索">
         <IconContext.Provider value={{ color: themeColorSelect, size: '24' }}>
           <IoSearch data-testid="icon" />
         </IconContext.Provider>

--- a/src/app/components/atoms/themeButton/ThemeButton.tsx
+++ b/src/app/components/atoms/themeButton/ThemeButton.tsx
@@ -1,49 +1,49 @@
 import { ThemeColorContext } from '@/contexts/ThemeColorContext';
 import React, { useContext } from 'react';
 import { IconContext } from 'react-icons';
-import { IoMdSunny } from "react-icons/io";
-import { IoMoon } from "react-icons/io5";
-
+import { IoMdSunny } from 'react-icons/io';
+import { IoMoon } from 'react-icons/io5';
 
 type IconProps = {
   onClick: () => void;
 };
 
-const ThemeButton = ({ onClick}: IconProps) => {
-  const {themeColor} = useContext(ThemeColorContext);
+const ThemeButton = ({ onClick }: IconProps) => {
+  const { themeColor } = useContext(ThemeColorContext);
 
-  let iconSelect, themeColorSelect;
-
-
-      switch (themeColor) {
-        case 'light':
-          iconSelect = <IoMoon data-testid="icon" />;
-          break;
-        case 'dark':
-          iconSelect = <IoMdSunny data-testid="icon" />;
-          break;
-        default:
-          iconSelect = <IoMoon data-testid="icon" />;
-          break;
-      }
-
+  let iconSelect, themeColorSelect, ariaLabel;
 
   switch (themeColor) {
     case 'light':
-      themeColorSelect='#454746';
+      iconSelect = <IoMoon data-testid="icon" />;
+      ariaLabel = 'ダークモードに切り替え';
       break;
     case 'dark':
-      themeColorSelect='C4C7C5';
+      iconSelect = <IoMdSunny data-testid="icon" />;
+      ariaLabel = 'ライトモードに切り替え';
       break;
     default:
-      themeColorSelect='#454746';
+      iconSelect = <IoMoon data-testid="icon" />;
+      ariaLabel = 'ダークモードに切り替え';
+      break;
+  }
+
+  switch (themeColor) {
+    case 'light':
+      themeColorSelect = '#454746';
+      break;
+    case 'dark':
+      themeColorSelect = 'C4C7C5';
+      break;
+    default:
+      themeColorSelect = '#454746';
       break;
   }
 
   return (
-  <button onClick={onClick} className=''>
-    <IconContext.Provider value={{ color: themeColorSelect, size: '24' }} >{iconSelect}</IconContext.Provider>
-  </button>
+    <button onClick={onClick} className="" aria-label={ariaLabel}>
+      <IconContext.Provider value={{ color: themeColorSelect, size: '24' }}>{iconSelect}</IconContext.Provider>
+    </button>
   );
 };
 


### PR DESCRIPTION
ユーザー補助機能の改善のために、「検索」と「テーマカラー」のアイコンボタンにaria-labelを追加しました。